### PR TITLE
respect includes within gitconfig

### DIFF
--- a/src/ws/gitpersona/persona.py
+++ b/src/ws/gitpersona/persona.py
@@ -33,7 +33,7 @@ CONFIG_PERSONA = re.compile('^persona\\.(.*?) ([^<]*) <(.*?)>$')
 
 def list_personas():
     result = {}
-    config = cmd('git config --global --get-regex ^persona\\.')
+    config = cmd('git config --global --includes --get-regex ^persona\\.')
     for line in config.splitlines():
         match = CONFIG_PERSONA.search(line)
         if not match:


### PR DESCRIPTION
This enables people to share their `.gitconfigure` without sharing all of their personas.
